### PR TITLE
[WIP] Lower monster upgrade default value to 10

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2230,7 +2230,7 @@ void options_manager::add_options_world_default()
     add( "MONSTER_UPGRADE_FACTOR", "world_default",
          translate_marker( "Monster evolution scaling factor" ),
          translate_marker( "A scaling factor that determines the time between monster upgrades.  A higher number means slower evolution.  Set to 0.00 to turn off monster upgrades." ),
-         0.0, 100, 1.0, 0.01
+         0.0, 100, 10.0, 0.01
        );
 
     add_empty_line();


### PR DESCRIPTION
#### Summary

SUMMARY: [Balance] "Lowering monster_upgrade_factor's default value to 10"

#### Purpose of change

Current default value, 1, makes the zombies to evolve too fast. For skilled players, this wouldn't be a problem since they know how to survive, and they might change this value to whatever they want.
But for new players, this is just noob killing machine.

#### Describe the solution

Changing monster_upgrade_factor's default value to 10, from 1.

#### Describe alternatives you've considered

Setting monster_upgrade_factor to 0.00, being disabled.
New players can turn on it after, if they want some harder challenge.

#### Testing

Not yet.

#### Additional context